### PR TITLE
Improve socket and gamepad state handling in connector.ts and actions.ts

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -147,6 +147,7 @@ export class Connector {
     this.subscribeMessage('serialport:open', () => {
       clearInterval(this.serial);
       this.serialConnected = true;
+      this.serial = null;
       log.info(this.logPrefix, `Connection to ${this.options.port} successful.`);
     });
 
@@ -244,13 +245,15 @@ export class Connector {
       log.info(this.logPrefix, msg);
       log.info(this.logPrefix, `Connection to ${this.options.port} successful.`);
     } else {
-      this.serial = setInterval( () => {
-        log.info(this.logPrefix, msg);
-        this.socket.emit('open', this.options.port, {
-          baudrate: Number(this.options.baudrate),
-          controllerType: this.options.controllerType
-      });
-  }, 2000);
+      if (!this.serial && !this.serialConnected) {
+        this.serial = setInterval(() => {
+          log.info(this.logPrefix, msg);
+          this.socket.emit('open', this.options.port, {
+            baudrate: Number(this.options.baudrate),
+            controllerType: this.options.controllerType
+          });
+        }, 2000);
+      }
     }
   };
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -252,7 +252,7 @@ export class Connector {
             baudrate: Number(this.options.baudrate),
             controllerType: this.options.controllerType
           });
-        }, 2000);
+        }, 5000);
       }
     }
   };

--- a/src/console.ts
+++ b/src/console.ts
@@ -100,8 +100,8 @@ function configureCLI(cli: Command, version: string) {
     .option('-b, --baudrate <baudrate>',                  'baud rate of serial port or cnc machine',                '115200')
 
     .addOption(new Option('-t, --controller-type <type>', 'controller type')
-      .choices(['grbl', 'marlin'])
-      .default('grbl'))
+      .choices(['Grbl', 'marlin'])
+      .default('Grbl'))
 
     .option('-s, --secret <secret>',                      'the secret key stored in the ~/.cncrc file')
     .option('--socket-address <address>',                 'cncjs address or hostname',                              'localhost')


### PR DESCRIPTION
The handling of connect and disconnect of the gamepad caused the software to crash. Probably some async stuff happening causing not to happen to everyone.

- connector.ts: Add checks for undefined socket to prevent errors on subscription and emit actions. Log warnings if socket is not connected.
- actions.ts: Add fallback values for axisStates and buttonStates to avoid undefined property access errors when gamepad state is not present.